### PR TITLE
Add JSON and CSV Output Formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ colored = "2.1"
 indicatif = "0.17"
 futures-util = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.8"
 dirs = "5.0"
 inquire = "0.9.1"
 clap = { version = "4.5", features = ["derive"] }
 playbill = "0.1.4"
 bytesize = "1.3"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -4,6 +4,7 @@
 
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
+use serde::Serialize;
 use std::time::Instant;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -45,6 +46,7 @@ fn format_speed(bytes_per_sec: f64, unit: SpeedUnit) -> String {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
 pub struct DownloadResult {
     pub status_code: u16,
     pub connect_time: f64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,14 @@
 
 mod config;
 mod downloader;
+mod output;
 mod servers;
 mod ui;
 
 use clap::Parser;
 use config::{load_config, SpeedUnit};
 use downloader::download_file;
+use output::OutputFormat;
 use servers::SERVERS;
 use ui::{show_menu, print_results, print_speed_only, print_download_header, wait_for_continue, ServerSelection};
 
@@ -30,6 +32,18 @@ struct Args {
     /// Speed unit format: bits-metric, bits-binary, bytes-metric, bytes-binary
     #[arg(short, long, value_name = "UNIT")]
     speed_unit: Option<String>,
+    
+    /// Output format: json, csv, or human (default)
+    #[arg(long, value_name = "FORMAT")]
+    format: Option<String>,
+    
+    /// Use compact JSON output (no pretty printing)
+    #[arg(long)]
+    compact: bool,
+    
+    /// Output JSON format (shorthand for --format json)
+    #[arg(long)]
+    json: bool,
 }
 
 #[tokio::main]
@@ -41,19 +55,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let speed_unit_str = args.speed_unit.as_ref().unwrap_or(&config.speed_unit);
     let speed_unit = SpeedUnit::from_string(speed_unit_str);
     
+    // Determine output format
+    let output_format = if args.json {
+        if args.compact {
+            OutputFormat::JsonCompact
+        } else {
+            OutputFormat::Json
+        }
+    } else if let Some(ref format_str) = args.format {
+        OutputFormat::from_string(format_str)
+    } else {
+        OutputFormat::Human
+    };
+    
     // If URL is provided, download it and save to current directory
     if let Some(url) = args.url {
         let filename = downloader::extract_filename(&url);
         let result = download_file(&url, Some(&filename), &config.user_agent, speed_unit).await?;
         
-        ui::print_speed_only(
-            result.status_code,
-            result.total_time,
-            result.bytes_downloaded,
-        );
-        
-        if result.status_code == 200 {
-            println!("Saved: {}", filename);
+        match output_format {
+            OutputFormat::Json => {
+                output::print_json(&result, "Custom URL", &url, false)?;
+            }
+            OutputFormat::JsonCompact => {
+                output::print_json(&result, "Custom URL", &url, true)?;
+            }
+            OutputFormat::Csv => {
+                output::print_csv(&result, "Custom URL", &url, true);
+            }
+            OutputFormat::Human => {
+                ui::print_speed_only(
+                    result.status_code,
+                    result.total_time,
+                    result.bytes_downloaded,
+                );
+                
+                if result.status_code == 200 {
+                    println!("Saved: {}", filename);
+                }
+            }
         }
         
         return Ok(());
@@ -70,29 +110,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     if interactive_mode {
         // Interactive mode - show menu and loop
-        run_interactive_mode(&config, speed_unit).await?;
+        run_interactive_mode(&config, speed_unit, output_format).await?;
     } else {
         // Non-interactive mode - run default server once
-        run_default_test(&config, speed_unit).await?;
+        run_default_test(&config, speed_unit, output_format).await?;
     }
 
     Ok(())
 }
 
-async fn run_default_test(config: &crate::config::Config, speed_unit: SpeedUnit) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_default_test(config: &crate::config::Config, speed_unit: SpeedUnit, output_format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     let server = &SERVERS[0];
     let result = download_file(server.url, None, &config.user_agent, speed_unit).await?;
     
-    print_speed_only(
-        result.status_code,
-        result.total_time,
-        result.bytes_downloaded,
-    );
+    match output_format {
+        OutputFormat::Json => {
+            output::print_json(&result, server.name, server.url, false)?;
+        }
+        OutputFormat::JsonCompact => {
+            output::print_json(&result, server.name, server.url, true)?;
+        }
+        OutputFormat::Csv => {
+            output::print_csv(&result, server.name, server.url, true);
+        }
+        OutputFormat::Human => {
+            print_speed_only(
+                result.status_code,
+                result.total_time,
+                result.bytes_downloaded,
+            );
+        }
+    }
 
     Ok(())
 }
 
-async fn run_interactive_mode(config: &crate::config::Config, speed_unit: SpeedUnit) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_interactive_mode(config: &crate::config::Config, speed_unit: SpeedUnit, output_format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let selection = match show_menu() {
             Ok(sel) => sel,
@@ -123,14 +176,27 @@ async fn run_interactive_mode(config: &crate::config::Config, speed_unit: SpeedU
 
         let result = download_file(&url, save_path.as_deref(), &config.user_agent, speed_unit).await?;
 
-        print_results(
-            result.status_code,
-            result.connect_time,
-            result.ttfb,
-            result.total_time,
-            result.bytes_downloaded,
-            save_path,
-        );
+        match output_format {
+            OutputFormat::Json => {
+                output::print_json(&result, &name, &url, false)?;
+            }
+            OutputFormat::JsonCompact => {
+                output::print_json(&result, &name, &url, true)?;
+            }
+            OutputFormat::Csv => {
+                output::print_csv(&result, &name, &url, true);
+            }
+            OutputFormat::Human => {
+                print_results(
+                    result.status_code,
+                    result.connect_time,
+                    result.ttfb,
+                    result.total_time,
+                    result.bytes_downloaded,
+                    save_path,
+                );
+            }
+        }
 
         println!();
         wait_for_continue().ok();

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,122 @@
+// Machine-readable output formats (JSON, CSV).
+
+use chrono::Utc;
+use serde::Serialize;
+use crate::downloader::DownloadResult;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OutputFormat {
+    Human,
+    Json,
+    JsonCompact,
+    Csv,
+}
+
+impl OutputFormat {
+    pub fn from_string(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "json" => OutputFormat::Json,
+            "json-compact" | "compact" => OutputFormat::JsonCompact,
+            "csv" => OutputFormat::Csv,
+            _ => OutputFormat::Human,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SpeedInfo {
+    mbps: f64,
+    mb_s: f64,
+}
+
+#[derive(Serialize)]
+struct ServerInfo {
+    name: String,
+    url: String,
+}
+
+#[derive(Serialize)]
+struct JsonOutput {
+    timestamp: String,
+    server: ServerInfo,
+    results: JsonResults,
+}
+
+#[derive(Serialize)]
+struct JsonResults {
+    status_code: u16,
+    bytes_downloaded: u64,
+    total_time: f64,
+    connect_time: f64,
+    ttfb: f64,
+    speed: SpeedInfo,
+}
+
+pub fn print_json(
+    result: &DownloadResult,
+    server_name: &str,
+    server_url: &str,
+    compact: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mbps = (result.bytes_downloaded as f64 * 8.0 / result.total_time) / 1_000_000.0;
+    let mb_s = (result.bytes_downloaded as f64 / result.total_time) / 1_000_000.0;
+
+    let output = JsonOutput {
+        timestamp: Utc::now().to_rfc3339(),
+        server: ServerInfo {
+            name: server_name.to_string(),
+            url: server_url.to_string(),
+        },
+        results: JsonResults {
+            status_code: result.status_code,
+            bytes_downloaded: result.bytes_downloaded,
+            total_time: result.total_time,
+            connect_time: result.connect_time,
+            ttfb: result.ttfb,
+            speed: SpeedInfo { mbps, mb_s },
+        },
+    };
+
+    if compact {
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    }
+
+    Ok(())
+}
+
+pub fn print_csv(
+    result: &DownloadResult,
+    server_name: &str,
+    server_url: &str,
+    include_header: bool,
+) {
+    let mbps = (result.bytes_downloaded as f64 * 8.0 / result.total_time) / 1_000_000.0;
+    let timestamp = Utc::now().to_rfc3339();
+
+    if include_header {
+        println!("timestamp,server_name,server_url,bytes_downloaded,total_time,connect_time,ttfb,speed_mbps,status_code");
+    }
+
+    println!(
+        "{},{},{},{},{:.3},{:.3},{:.3},{:.2},{}",
+        timestamp,
+        escape_csv(server_name),
+        escape_csv(server_url),
+        result.bytes_downloaded,
+        result.total_time,
+        result.connect_time,
+        result.ttfb,
+        mbps,
+        result.status_code
+    );
+}
+
+fn escape_csv(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}


### PR DESCRIPTION
## Description

Implements machine-readable output formats for scripting and automation as requested in issue #6.

## Features Added

- **--json flag**: Pretty-printed JSON output
- **--compact flag**: Minified JSON output for piping
- **--format csv**: CSV output with header row
- All structured outputs include:
  - RFC3339 timestamp
  - Server name and URL
  - Full download metrics (status, bytes, times, speed)

## Examples

### JSON Output
```bash
speedo -n --json
```

### Compact JSON (for piping to jq)
```bash
speedo -n --json --compact | jq '.results.speed.mbps'
```

### CSV Output
```bash
speedo -n --format csv >> speed_tests.csv
```

## Testing

- ✅ Builds successfully
- ✅ JSON output tested (pretty and compact)
- ✅ CSV output tested with headers
- ✅ Backward compatibility maintained (human output still default)

## Dependencies

- Added `serde_json` for JSON serialization
- Added `chrono` for RFC3339 timestamps

Closes #6